### PR TITLE
ioBroker Installation file

### DIFF
--- a/ioBroker/commands.sh
+++ b/ioBroker/commands.sh
@@ -1,0 +1,27 @@
+echo "ioBroker installieren"
+sudo mkdir /opt/iobroker
+sudo chmod 777 /opt/iobroker
+cd /opt/iobroker
+sudo npm install -g npm@latest
+sudo npm install iobroker --unsafe-perm
+cat > iobroker.service << EOF
+[Unit]
+Description=ioBroker IoT integration platform
+Documentation=http://iobroker.net
+After=syslog.target network-online.target
+[Service]
+Type=simple
+User=root
+ExecStart=/usr/bin/node /opt/iobroker/node_modules/iobroker.js-controller/controller.js
+Restart=on-failure
+RestartSec=10
+KillMode=process
+[Install]
+WantedBy=multi-user.target
+EOF
+
+echo "Autostart für ioBroker einrichten"
+sudo mv iobroker.service /etc/systemd/system/iobroker.service
+sudo systemctl daemon-reload
+sudo systemctl enable iobroker
+sudo systemctl start iobroker


### PR DESCRIPTION
Based on http://www.iobroker.net/docu/?page_id=5106&lang=de - will need to manually add the homee adapter, once it is developed. Please test before release. My test was successful with a Pi3 (older versions should be tested, too). 
BUT - it must currently be run as root (see here: https://github.com/ioBroker/ioBroker/issues/47), I do not yet have another solution, as some of the adapters need root (by design)... played around with a separate iobroker user (sudo adduser iobroker --no-create-home --disabled-password --disabled-login) that was then added to sudo (usermod -aG sudo iobroker) but this did not work either. If we release it, we should mark it experimental (to prepare the upcoming adapter).